### PR TITLE
Add GA release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+---
+name: "tagged-release"
+
+on:
+  push:
+    tags:
+      - "r*"
+
+jobs:
+  publish-image:
+    name: "Publish Docker Image to Docker Hub"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Push image
+        run: |
+          cd cassandra-4.0.6
+          IMAGE_NAME=shotover/cassandra-test:4.0.6-${GITHUB_REF/refs\/tags\//}
+          docker build -t $IMAGE_NAME .
+          docker push $IMAGE_NAME
+
+          cd ../cassandra-3.11.13
+          IMAGE_NAME=shotover/cassandra-test:3.11.13-${GITHUB_REF/refs\/tags\//}
+          docker build -t $IMAGE_NAME .
+          docker push $IMAGE_NAME


### PR DESCRIPTION
The plan for releases is to make a simple incrementing tag r1 -> r2 -> r3 ..., at each new release. Each such release will be considered a breaking release and shotover will pin to an exact release to avoid breakage.

Config is modified from https://github.com/shotover/shotover-proxy/blob/main/.github/workflows/release.yaml
