### PR TITLE
readme: fix image name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ The faster startup time is achieved by hardcoding the tokens for each node:
 version: "3.3"
 services:
   cassandra-one:
-    image: shotover/cassandra-test:4.0.6
+    image: shotover/cassandra-test:4.0.6-r1
     ports:
       - "9042:9042"
     environment:
@@ -50,7 +50,7 @@ networks:
 
 services:
   cassandra-one:
-    image: &image shotover/cassandra-test:4.0.6
+    image: &image shotover/cassandra-test:4.0.6-r1
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2


### PR DESCRIPTION
We do not publish additional unrevisioned tags like other docker images do, so the image names in the readme are not valid image names. This is done because we do not want changes to the image suddenly altering how our tests run, possibly causing failures.
This PR fixes that by using the actual image name.