### PR TITLE
aarch64 support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,29 +7,47 @@ on:
       - "r*"
 
 jobs:
-  publish-image:
-    name: "Publish Docker Image to Docker Hub"
-    runs-on: ubuntu-latest
+  build-image:
+    name: "Build ${{ matrix.cassandra }} (${{ matrix.runner }})"
+    strategy:
+      matrix:
+        cassandra: ["4.0.6", "3.11.13", "5.0-rc1"]
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: actions/checkout@v3
-      - name: Push image
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push single-platform image
         run: |
-          cd cassandra-4.0.6
-          IMAGE_NAME=shotover/cassandra-test:4.0.6-${GITHUB_REF/refs\/tags\//}
-          docker build -t $IMAGE_NAME .
-          docker push $IMAGE_NAME
+          TAG=${GITHUB_REF/refs\/tags\//}
+          ARCH=$(dpkg --print-architecture)
+          docker buildx build cassandra-${{ matrix.cassandra }} \
+            -t shotover/cassandra-test:${{ matrix.cassandra }}-$TAG-$ARCH \
+            --push
 
-          cd ../cassandra-3.11.13
-          IMAGE_NAME=shotover/cassandra-test:3.11.13-${GITHUB_REF/refs\/tags\//}
-          docker build -t $IMAGE_NAME .
-          docker push $IMAGE_NAME
-
-          cd ../cassandra-5.0-rc1
-          IMAGE_NAME=shotover/cassandra-test:5.0-rc1-${GITHUB_REF/refs\/tags\//}
-          docker build -t $IMAGE_NAME .
-          docker push $IMAGE_NAME
+  publish-manifest:
+    name: "Publish manifest for ${{ matrix.cassandra }}"
+    needs: build-image
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        cassandra: ["4.0.6", "3.11.13", "5.0-rc1"]
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create and push multi-arch manifest
+        run: |
+          TAG=${GITHUB_REF/refs\/tags\//}
+          IMAGE=shotover/cassandra-test:${{ matrix.cassandra }}-$TAG
+          docker buildx imagetools create -t $IMAGE \
+            $IMAGE-amd64 \
+            $IMAGE-arm64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,21 @@
+---
+name: "Test image build"
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-image:
+    name: "Build ${{ matrix.cassandra }} (${{ matrix.runner }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        cassandra: ["4.0.6", "3.11.13", "5.0-rc1"]
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: |
+          docker buildx build cassandra-${{ matrix.cassandra }}


### PR DESCRIPTION
closes https://github.com/shotover/cassandra-test-images/issues/2

These `cassandra-test` images have previously only been built for x86_64 even though the upstream image its based on supports both aarch64 and x86_64.
This is particularly problematic because by default shotover's ec2-cargo tool runs on a graviton instance, so all of our cassandra tests fail by default :/

This PR changes CI of this repo so that:
* adds a workflow that runs on PRs and builds all images on all platforms.
  + we can see this works by looking at the workflows on this PR
* the release workflow now creates a multi arch docker image, enabling support for aarch64
  + its hard to verify this without actually merging it first. I've run this workflow on my fork of this repo which builds the individual images but then fails because the push fails due to lack of tokens. But it should work, and worst case we merge a fix PR afterwards to resolve any bug. 🤞 